### PR TITLE
Update Links to New Lkml for Pages/Tracks Analysis

### DIFF
--- a/_7b_session_tracks_pages_analysis.md
+++ b/_7b_session_tracks_pages_analysis.md
@@ -4,15 +4,15 @@ Use this pattern when customers would like to include both pages and tracks even
 
 ![page track analysis](http://gdurl.com/46Cz)
 
-A. [**Alias Mapping**] (_A_alias_mapping.view.lookml) - User ID Consolidation from Tracks and Pages Table
+A. [**Alias Mapping**](_A_alias_mapping.view.lkml) - User ID Consolidation from Tracks and Pages Table
 
-B. [**Mapped Events**](_B_mapped_events.view.lookml) - Serves to map all events (Tracks and Pages) to universal user id as first step in sessionization. Ranks events by User and get the time difference between one event to the next.
+B. [**Mapped Events**](_B_mapped_events.view.lkml) - Serves to map all events (Tracks and Pages) to universal user id as first step in sessionization. Ranks events by User and get the time difference between one event to the next.
 
-C. [**Session Track Pages**](_C_session_pg_tracks.view.lookml) - Creates sessions from Mapped Events by identifying a period of inactivity greater than 30 minutes, ending the current session and creating a new one.
+C. [**Session Track Pages**](_D_session_pg_tracks.view.lkml) - Creates sessions from Mapped Events by identifying a period of inactivity greater than 30 minutes, ending the current session and creating a new one.
 
-D. [**Event Facts**](_D_event_facts.view.lookml) - Maps events to session ids. This table will the starting point for exploration as it contains all the necessary keys (Session ID, Universal User ID) for all relevant joins. Session or User fact tables can be created from Event facts to speed up query results.
+D. [**Event Facts**](_E_event_facts.view.lkml) - Maps events to session ids. This table will the starting point for exploration as it contains all the necessary keys (Session ID, Universal User ID) for all relevant joins. Session or User fact tables can be created from Event facts to speed up query results.
 
-Looker Model - These individual files can be integrated in the [Pages Model File](pages.model.lookml). Event_id is NOT the primary key for Events, so joins must use multiple identifiers on required fields, like anonymous_id, received_at, and event_id. Also event_id may be called id, just swap the name.
+Looker Model - These individual files can be integrated in the [Pages Model File](bigquery_segment_pages.model.lkml). Event_id is NOT the primary key for Events, so joins must use multiple identifiers on required fields, like anonymous_id, received_at, and event_id. Also event_id may be called id, just swap the name.
 
 [:point_right:](_8_sample_advanced_design_patterns.md) Continue to [Sample Advanced Design Patterns](_8_sample_advanced_design_patterns.md)
 


### PR DESCRIPTION
_7b_session_tracks_pages_analysis.md

Looks like a new "_C_" view was added for this analysis method, so C and D on the page actually reference _D and _E, respectively. Hope this helps, if not, no problem deleting the PR!